### PR TITLE
Some fixes

### DIFF
--- a/playmusicdecrypter.py
+++ b/playmusicdecrypter.py
@@ -25,6 +25,8 @@ import sqlite3
 
 import superadb
 
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class PlayMusicDecrypter:
     """Decrypt MP3 file from Google Play Music offline storage (All Access)"""
@@ -121,8 +123,8 @@ def pull_database(destination_dir=".", adb="adb"):
     print("Downloading Google Play Music database from device...")
     try:
         adb = superadb.SuperAdb(executable=adb)
-    except RuntimeError:
-        print("  Device is not connected! Exiting...")
+    except RuntimeError as e:
+        print("  {} Exiting...".format(e.message))
         sys.exit(1)
 
     if not os.path.isdir(destination_dir):
@@ -140,8 +142,8 @@ def pull_library(source_dir="/data/data/com.google.android.music/files/music", d
     print("Downloading encrypted MP3 files from device...")
     try:
         adb = superadb.SuperAdb(executable=adb)
-    except RuntimeError:
-        print("  Device is not connected! Exiting...")
+    except RuntimeError as e:
+        print("  {} Exiting...".format(e.message))
         sys.exit(1)
 
     if not os.path.isdir(destination_dir):

--- a/superadb.py
+++ b/superadb.py
@@ -109,11 +109,12 @@ class SuperAdb(object):
             raise RuntimeError("Device is not connected!")
 
         # Setup reverse port forwarding
-        self.start_reverse_forwarding()
+        if self.start_reverse_forwarding():
+            raise RuntimeError("Can't start adb reverse port forwarding!")
 
     def adb(self, *cmd):
         """Call adb command"""
-        return subprocess.call([self.executable] + list(cmd))
+        return subprocess.call([self.executable] + list(cmd), stderr=subprocess.STDOUT, stdout=open(os.devnull, 'w'))
 
     def start_server(self):
         """Start adb server"""
@@ -183,8 +184,8 @@ def main():
 
     try:
         adb = SuperAdb(executable=options.adb)
-    except RuntimeError:
-        print("Device is not connected!")
+    except RuntimeError as e:
+        print("  {} Exiting...".format(e.message))
         sys.exit(1)
 
     cmd = args[0]


### PR DESCRIPTION
1. Terminate with intelligible error message when adb reverse can't start (for example when reverse command isn't present in adb, etc...).
2. Suppress all output for adb command.
3. Fix trouble with non-ascii symbols in file paths.
